### PR TITLE
Fixes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,10 @@
-ADMIN_SECRET=   //obtain from https://kmc.kaltura.com/index.php/kmcng/settings/integrationSettings
-PARTNER_ID=     //obtain from https://kmc.kaltura.com/index.php/kmcng/settings/integrationSettings
-PLAYER_ID=      //obtain from https://kmc.kaltura.com/index.php/kmcng/studio/v3
+# obtain from https://kmc.kaltura.com/index.php/kmcng/settings/integrationSettings
+PARTNER_ID=
+# obtain from https://kmc.kaltura.com/index.php/kmcng/settings/integrationSettings
+ADMIN_SECRET=
+SERVICE_URL=https://www.kaltura.com
+# obtain from https://kmc.kaltura.com/index.php/kmcng/studio/v3
+PLAYER_ID=
 KS_TYPE=USER
 
 #Key used for encrypting session cookies

--- a/lib/kalturaClientFactory.js
+++ b/lib/kalturaClientFactory.js
@@ -1,8 +1,8 @@
 const kaltura = require('kaltura-client');
 
-const {ADMIN_SECRET: secret, PARTNER_ID: partnerId, KS_TYPE: ksType} = process.env;
+const {ADMIN_SECRET: secret, PARTNER_ID: partnerId, KS_TYPE: ksType, SERVICE_URL: serviceUrl} = process.env;
 let config = new kaltura.Configuration();
-config.serviceUrl = "http://www.kaltura.com";
+config.serviceUrl = serviceUrl;
 
 const defaultKSType = kaltura.enums.SessionType[ksType || 'USER'];
 


### PR DESCRIPTION
- with the correct template and the way the values are read, the code will fail if the original comments are left in place
- Read Kaltura's API endpoint (aka service URL) from the .env file and use HTTPs by default

Additional points that need addressing:
- Failure in generating a KS should be caught (`START_SESSION_ERROR`) and propagated into the UI
- https://github.com/kaltura-vpaas/example-tikrok/blob/main/views/record.ejs#L13 - File is missing from the repo
- If `.env` is not present (or readable), execution should stop immediately and never reach:
> /tmp/example-tikrok/node_modules/cookie-session/index.js:55
  if (!keys && opts.signed) throw new Error('.keys required.');
- Support for HTTPs ought to be included, https://github.com/Eyevinn/ott-multiview/pull/7/files see as reference
